### PR TITLE
Add ability to use a service with multiple interfaces

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,6 @@
+Contributors
+============
+
+These people have contributed to ktor-retrofit:
+
+  * Josh Feinberg ([joshafeinberg](http://github.com/joshafeinberg))

--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
@@ -56,11 +56,6 @@ import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.javaType
 
 fun Route.retrofitService(service: Any) {
-/*  val serviceInterface = service::class.superclasses.single { it != Any::class }
-  for (declaredFunction in serviceInterface.declaredFunctions) {
-    if (!declaredFunction.isSuspend) TODO("only suspend Retrofit functions are supported")
-    process(service, declaredFunction)
-  }*/
   service::class.superclasses
     .filter { it != Any::class }
     .forEach { serviceInterface ->

--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
@@ -56,11 +56,20 @@ import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.javaType
 
 fun Route.retrofitService(service: Any) {
-  val serviceInterface = service::class.superclasses.single { it != Any::class }
+/*  val serviceInterface = service::class.superclasses.single { it != Any::class }
   for (declaredFunction in serviceInterface.declaredFunctions) {
     if (!declaredFunction.isSuspend) TODO("only suspend Retrofit functions are supported")
     process(service, declaredFunction)
-  }
+  }*/
+  service::class.superclasses
+    .filter { it != Any::class }
+    .forEach { serviceInterface ->
+      serviceInterface.declaredFunctions
+        .forEach { declaredFunction ->
+          if (!declaredFunction.isSuspend) TODO("only suspend Retrofit functions are supported")
+          process(service, declaredFunction)
+        }
+    }
 }
 
 class RetrofitService {

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceService.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceService.kt
@@ -1,0 +1,47 @@
+package com.bnorm.ktor.retrofit
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface MultipleInterfaceService : MultipleInterfaceServiceOne, MultipleInterfaceServiceTwo
+
+interface MultipleInterfaceServiceOne {
+    @GET("string")
+    suspend fun getString(): List<String>
+
+    @GET("string/{id}")
+    suspend fun getString(@Path("id") id: Long): String
+}
+
+interface MultipleInterfaceServiceTwo {
+    @GET("int")
+    suspend fun getInt(): List<Int>
+}
+
+class MultipleInterfaceServiceWrapper(
+    multipleInterfaceServiceOne: MultipleInterfaceServiceOne,
+    multipleInterfaceServiceTwo: MultipleInterfaceServiceTwo
+) : MultipleInterfaceService,
+    MultipleInterfaceServiceOne by multipleInterfaceServiceOne,
+    MultipleInterfaceServiceTwo by multipleInterfaceServiceTwo
+
+val multipleInterfaceService = MultipleInterfaceServiceWrapper(
+    multipleInterfaceServiceOne = object : MultipleInterfaceServiceOne {
+        override suspend fun getString(): List<String> {
+            return listOf("one", "two")
+        }
+
+        override suspend fun getString(id: Long): String {
+            return when (id) {
+                0L -> "one"
+                1L -> "two"
+                else -> throw IndexOutOfBoundsException("id=$id")
+            }
+        }
+    },
+    multipleInterfaceServiceTwo = object : MultipleInterfaceServiceTwo {
+        override suspend fun getInt(): List<Int> {
+            return listOf(1, 2)
+        }
+    }
+)

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceService.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceService.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2018 Brian Norman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.bnorm.ktor.retrofit
 
 import retrofit2.http.GET

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceServiceTest.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceServiceTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2020 Brian Norman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author Josh Feinberg (joshafeinberg)
+ */
+
+package com.bnorm.ktor.retrofit
+
+import io.ktor.application.Application
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.features.ContentNegotiation
+import io.ktor.features.StatusPages
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.jackson.jackson
+import io.ktor.response.respond
+import io.ktor.routing.route
+import io.ktor.routing.routing
+import io.ktor.server.testing.TestApplicationEngine
+import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.withTestApplication
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+fun Application.installMultipleFeature() {
+  install(ContentNegotiation) {
+    jackson { }
+  }
+
+  install(RetrofitService) {
+    service(baseUrl = "api", service = multipleInterfaceService)
+  }
+}
+
+fun Application.installMultipleRoute() {
+  install(ContentNegotiation) {
+    jackson { }
+  }
+
+  routing {
+    route("api") {
+      retrofitService(service = multipleInterfaceService)
+    }
+  }
+}
+
+private fun TestApplicationEngine.runMultipleInterfaceTest() {
+  with(handleRequest(HttpMethod.Get, "/api/string")) {
+    assertEquals(HttpStatusCode.OK, response.status())
+    assertEquals("[\"one\",\"two\"]", response.content)
+  }
+
+
+  with(handleRequest(HttpMethod.Get, "/api/int")) {
+    assertEquals(HttpStatusCode.OK, response.status())
+    assertEquals("[1,2]", response.content)
+  }
+}
+
+class MultipleInterfaceServiceTest {
+  @Test
+  fun feature(): Unit = withTestApplication(Application::installMultipleFeature) {
+    runMultipleInterfaceTest()
+  }
+
+  @Test
+  fun route(): Unit = withTestApplication(Application::installMultipleRoute) {
+    runMultipleInterfaceTest()
+  }
+
+  @Test
+  fun error(): Unit = withTestApplication({
+    installMultipleFeature()
+    install(StatusPages) {
+      exception<Throwable> {
+        call.respond(HttpStatusCode.InternalServerError, "Error")
+      }
+    }
+  }) {
+    with(handleRequest(HttpMethod.Get, "/api/string/2")) {
+      assertEquals(HttpStatusCode.InternalServerError, response.status())
+    }
+  }
+}

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceServiceTest.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceServiceTest.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * @author Josh Feinberg (joshafeinberg)
- */
-
 package com.bnorm.ktor.retrofit
 
 import io.ktor.application.Application


### PR DESCRIPTION
The reason for this PR is to allow a retrofit service to implement multiple interfaces. This works out well when wanting to separate network calls into different controllers.

Resolves https://github.com/bnorm/ktor-retrofit/issues/3