### PR TITLE
Stop allowing duplicate routes

### DIFF
--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
@@ -60,7 +60,7 @@ import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.javaType
 
-private val injectorKey = AttributeKey<MutableMap<HttpMethod, MutableSet<RegisteredRoute>>>("routes")
+private val injectorKey = AttributeKey<MutableMap<RegisteredRoute, RegisteredRoute>>("routes")
 
 fun Route.retrofitService(service: Any) {
   if (!attributes.contains(injectorKey)) {
@@ -195,12 +195,11 @@ private fun Route.checkRegisteredRoute(
 ) {
   val registeredRoutes = attributes[injectorKey]
   val newRoute = RegisteredRoute(method, baseUrl.toString(), path, serviceInterface.qualifiedName, methodName)
-  val registeredPaths = registeredRoutes.getOrPut(method) { mutableSetOf() }
-  val registeredPath = registeredPaths.firstOrNull { registeredPath -> registeredPath == newRoute }
+  val registeredPath = registeredRoutes[newRoute]
   if (registeredPath != null) {
     throw IllegalStateException("@${method.value}(\"$path\") is already registered in ${registeredPath.serviceInterface}::${registeredPath.methodName}")
   }
-  registeredRoutes[method] = registeredPaths.apply { add(newRoute) }
+  registeredRoutes[newRoute] = newRoute
 }
 
 private suspend fun respond(call: ApplicationCall, service: Any, function: KFunction<*>) {

--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/RetrofitService.kt
@@ -60,16 +60,20 @@ import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.javaType
 
-internal val registeredRoutes = mutableMapOf<HttpMethod, Set<RegisteredRoute>>()
+private val injectorKey = AttributeKey<MutableMap<HttpMethod, MutableSet<RegisteredRoute>>>("routes")
 
 fun Route.retrofitService(service: Any) {
+  if (!attributes.contains(injectorKey)) {
+    attributes.put(injectorKey, mutableMapOf())
+  }
+
   service::class.superclasses
     .filter { it != Any::class }
     .forEach { serviceInterface ->
       serviceInterface.declaredFunctions
         .forEach { declaredFunction ->
           if (!declaredFunction.isSuspend) TODO("only suspend Retrofit functions are supported")
-          process(service, declaredFunction)
+          process(service, serviceInterface, declaredFunction)
         }
     }
 }
@@ -101,12 +105,12 @@ class RetrofitService {
   }
 }
 
-private fun Route.process(service: Any, function: KFunction<*>) {
+private fun Route.process(service: Any, serviceInterface: KClass<*>, function: KFunction<*>) {
   val annotations = function.annotations
 
   val get = annotations.filterIsInstance<GET>().singleOrNull()
   if (get != null) {
-    checkRegisteredRoute(HttpMethod.Get, this, get.value, function.name)
+    checkRegisteredRoute(HttpMethod.Get, this, get.value, serviceInterface, function.name)
     get(get.value) {
       respond(call, service, function)
     }
@@ -115,7 +119,7 @@ private fun Route.process(service: Any, function: KFunction<*>) {
 
   val post = annotations.filterIsInstance<POST>().singleOrNull()
   if (post != null) {
-    checkRegisteredRoute(HttpMethod.Post, this, post.value, function.name)
+    checkRegisteredRoute(HttpMethod.Post, this, post.value, serviceInterface, function.name)
     post(post.value) {
       respond(call, service, function)
     }
@@ -124,7 +128,7 @@ private fun Route.process(service: Any, function: KFunction<*>) {
 
   val delete = annotations.filterIsInstance<DELETE>().singleOrNull()
   if (delete != null) {
-    checkRegisteredRoute(HttpMethod.Delete, this, delete.value, function.name)
+    checkRegisteredRoute(HttpMethod.Delete, this, delete.value, serviceInterface, function.name)
     delete(delete.value) {
       respond(call, service, function)
     }
@@ -133,7 +137,7 @@ private fun Route.process(service: Any, function: KFunction<*>) {
 
   val put = annotations.filterIsInstance<PUT>().singleOrNull()
   if (put != null) {
-    checkRegisteredRoute(HttpMethod.Put, this, put.value, function.name)
+    checkRegisteredRoute(HttpMethod.Put, this, put.value, serviceInterface, function.name)
     put(put.value) {
       respond(call, service, function)
     }
@@ -142,7 +146,7 @@ private fun Route.process(service: Any, function: KFunction<*>) {
 
   val patch = annotations.filterIsInstance<PATCH>().singleOrNull()
   if (patch != null) {
-    checkRegisteredRoute(HttpMethod.Patch, this, patch.value, function.name)
+    checkRegisteredRoute(HttpMethod.Patch, this, patch.value, serviceInterface, function.name)
     patch(patch.value) {
       respond(call, service, function)
     }
@@ -151,7 +155,7 @@ private fun Route.process(service: Any, function: KFunction<*>) {
 
   val head = annotations.filterIsInstance<HEAD>().singleOrNull()
   if (head != null) {
-    checkRegisteredRoute(HttpMethod.Head, this, head.value, function.name)
+    checkRegisteredRoute(HttpMethod.Head, this, head.value, serviceInterface, function.name)
     head(head.value) {
       respond(call, service, function)
     }
@@ -160,7 +164,7 @@ private fun Route.process(service: Any, function: KFunction<*>) {
 
   val options = annotations.filterIsInstance<OPTIONS>().singleOrNull()
   if (options != null) {
-    checkRegisteredRoute(HttpMethod.Options, this, options.value, function.name)
+    checkRegisteredRoute(HttpMethod.Options, this, options.value, serviceInterface, function.name)
     options(options.value) {
       respond(call, service, function)
     }
@@ -170,7 +174,7 @@ private fun Route.process(service: Any, function: KFunction<*>) {
   val http = annotations.filterIsInstance<HTTP>().singleOrNull()
   if (http != null) {
     val method = HttpMethod.parse(http.method)
-    checkRegisteredRoute(method, this, http.path, function.name)
+    checkRegisteredRoute(method, this, http.path, serviceInterface, function.name)
     route(http.path, method) {
       handle {
         respond(call, service, function)
@@ -182,18 +186,21 @@ private fun Route.process(service: Any, function: KFunction<*>) {
   TODO("implement the rest of the function annotations : $annotations")
 }
 
-private fun checkRegisteredRoute(
+private fun Route.checkRegisteredRoute(
   method: HttpMethod,
   baseUrl: Route,
   path: String,
+  serviceInterface: KClass<*>,
   methodName: String
 ) {
-  val newRoute = RegisteredRoute(method, baseUrl.toString(), path, methodName)
-  val registeredPaths = registeredRoutes.getOrDefault(method, mutableSetOf())
-  if (registeredPaths.contains(newRoute)) {
-    throw IllegalStateException("@${method.value}(\"$path\") is already registered")
+  val registeredRoutes = attributes[injectorKey]
+  val newRoute = RegisteredRoute(method, baseUrl.toString(), path, serviceInterface.qualifiedName, methodName)
+  val registeredPaths = registeredRoutes.getOrPut(method) { mutableSetOf() }
+  val registeredPath = registeredPaths.firstOrNull { registeredPath -> registeredPath == newRoute }
+  if (registeredPath != null) {
+    throw IllegalStateException("@${method.value}(\"$path\") is already registered in ${registeredPath.serviceInterface}::${registeredPath.methodName}")
   }
-  registeredRoutes[method] = registeredPaths.toMutableSet().apply { add(newRoute) }
+  registeredRoutes[method] = registeredPaths.apply { add(newRoute) }
 }
 
 private suspend fun respond(call: ApplicationCall, service: Any, function: KFunction<*>) {

--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
@@ -4,6 +4,7 @@ import io.ktor.http.HttpMethod
 
 data class RegisteredRoute private constructor(
     val method: HttpMethod,
+    val baseUrl: String?,
     val route: String
 ) {
     // not included in constructor for equals/hashcode
@@ -12,9 +13,10 @@ data class RegisteredRoute private constructor(
 
     constructor(
         method: HttpMethod,
+        baseUrl: String?,
         route: String,
         methodName: String
-    ) : this(method, route) {
+    ) : this(method, baseUrl, route) {
         this.methodName = methodName
     }
 }

--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
@@ -2,14 +2,13 @@ package com.bnorm.ktor.retrofit.internal
 
 import io.ktor.http.HttpMethod
 
-data class RegisteredRoute private constructor(
+internal data class RegisteredRoute private constructor(
     val method: HttpMethod,
     val baseUrl: String?,
     val route: String
 ) {
     // not included in constructor for equals/hashcode
-    var methodName: String = ""
-        private set
+    private var methodName: String = ""
 
     constructor(
         method: HttpMethod,

--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
@@ -1,0 +1,20 @@
+package com.bnorm.ktor.retrofit.internal
+
+import io.ktor.http.HttpMethod
+
+data class RegisteredRoute private constructor(
+    val method: HttpMethod,
+    val route: String
+) {
+    // not included in constructor for equals/hashcode
+    var methodName: String = ""
+        private set
+
+    constructor(
+        method: HttpMethod,
+        route: String,
+        methodName: String
+    ) : this(method, route) {
+        this.methodName = methodName
+    }
+}

--- a/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
+++ b/ktor-retrofit/src/main/kotlin/com/bnorm/ktor/retrofit/internal/RegisteredRoute.kt
@@ -8,14 +8,19 @@ internal data class RegisteredRoute private constructor(
     val route: String
 ) {
     // not included in constructor for equals/hashcode
-    private var methodName: String = ""
+    var serviceInterface: String? = ""
+        private set
+    var methodName: String = ""
+        private set
 
     constructor(
         method: HttpMethod,
         baseUrl: String?,
         route: String,
+        serviceInterface: String?,
         methodName: String
     ) : this(method, baseUrl, route) {
+        this.serviceInterface = serviceInterface
         this.methodName = methodName
     }
 }

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/DuplicateRouteService.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/DuplicateRouteService.kt
@@ -1,0 +1,30 @@
+package com.bnorm.ktor.retrofit
+
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface DuplicateRouteService {
+
+    @GET("route")
+    suspend fun getRoute(): String
+
+    @GET("route/{id}")
+    suspend fun getRoute(@Path("id") id: Long): String
+
+    @POST("route")
+    suspend fun postRoute(): String
+
+    @GET("route")
+    suspend fun getRouteAgain(): String
+}
+
+val duplicateRouteService = object : DuplicateRouteService {
+    override suspend fun getRoute(): String = ""
+
+    override suspend fun getRoute(id: Long): String = ""
+
+    override suspend fun postRoute(): String = ""
+
+    override suspend fun getRouteAgain(): String = ""
+}

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/DuplicateRouteServiceTest.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/DuplicateRouteServiceTest.kt
@@ -1,0 +1,30 @@
+package com.bnorm.ktor.retrofit
+
+import io.ktor.server.testing.withTestApplication
+import org.hamcrest.core.StringContains
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+
+class DuplicateRouteServiceTest {
+
+    @Rule @JvmField
+    val exceptionRule = ExpectedException.none()
+
+    @Test
+    fun feature() {
+        exceptionRule.expect(IllegalStateException::class.java)
+        exceptionRule.expectMessage("@GET(\"route\") is already registered")
+        withTestApplication(installFeature(duplicateRouteService)) {
+        }
+    }
+
+    @Test
+    fun route() {
+        exceptionRule.expect(IllegalStateException::class.java)
+        exceptionRule.expectMessage("@GET(\"route\") is already registered")
+        withTestApplication(installRoute(duplicateRouteService)) {
+        }
+    }
+}

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/DuplicateRouteServiceTest.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/DuplicateRouteServiceTest.kt
@@ -6,7 +6,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 
-
 class DuplicateRouteServiceTest {
 
     @Rule @JvmField
@@ -15,7 +14,7 @@ class DuplicateRouteServiceTest {
     @Test
     fun feature() {
         exceptionRule.expect(IllegalStateException::class.java)
-        exceptionRule.expectMessage("@GET(\"route\") is already registered")
+        exceptionRule.expectMessage(EXPECTED_ERROR_MESSAGE)
         withTestApplication(installFeature(duplicateRouteService)) {
         }
     }
@@ -23,8 +22,10 @@ class DuplicateRouteServiceTest {
     @Test
     fun route() {
         exceptionRule.expect(IllegalStateException::class.java)
-        exceptionRule.expectMessage("@GET(\"route\") is already registered")
+        exceptionRule.expectMessage(EXPECTED_ERROR_MESSAGE)
         withTestApplication(installRoute(duplicateRouteService)) {
         }
     }
 }
+
+private const val EXPECTED_ERROR_MESSAGE = "@GET(\"route\") is already registered in com.bnorm.ktor.retrofit.DuplicateRouteService::getRoute"

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceServiceTest.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/MultipleInterfaceServiceTest.kt
@@ -16,44 +16,17 @@
 
 package com.bnorm.ktor.retrofit
 
-import io.ktor.application.Application
 import io.ktor.application.call
 import io.ktor.application.install
-import io.ktor.features.ContentNegotiation
 import io.ktor.features.StatusPages
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
-import io.ktor.jackson.jackson
 import io.ktor.response.respond
-import io.ktor.routing.route
-import io.ktor.routing.routing
 import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
-
-fun Application.installMultipleFeature() {
-  install(ContentNegotiation) {
-    jackson { }
-  }
-
-  install(RetrofitService) {
-    service(baseUrl = "api", service = multipleInterfaceService)
-  }
-}
-
-fun Application.installMultipleRoute() {
-  install(ContentNegotiation) {
-    jackson { }
-  }
-
-  routing {
-    route("api") {
-      retrofitService(service = multipleInterfaceService)
-    }
-  }
-}
 
 private fun TestApplicationEngine.runMultipleInterfaceTest() {
   with(handleRequest(HttpMethod.Get, "/api/string")) {
@@ -70,18 +43,18 @@ private fun TestApplicationEngine.runMultipleInterfaceTest() {
 
 class MultipleInterfaceServiceTest {
   @Test
-  fun feature(): Unit = withTestApplication(Application::installMultipleFeature) {
+  fun feature(): Unit = withTestApplication(installFeature(multipleInterfaceService)) {
     runMultipleInterfaceTest()
   }
 
   @Test
-  fun route(): Unit = withTestApplication(Application::installMultipleRoute) {
+  fun route(): Unit = withTestApplication(installRoute(multipleInterfaceService)) {
     runMultipleInterfaceTest()
   }
 
   @Test
   fun error(): Unit = withTestApplication({
-    installMultipleFeature()
+    installFeature(multipleInterfaceService).invoke(this)
     install(StatusPages) {
       exception<Throwable> {
         call.respond(HttpStatusCode.InternalServerError, "Error")

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/install.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/install.kt
@@ -26,6 +26,8 @@ import io.ktor.routing.routing
 typealias ApplicationScope = Application.() -> Unit
 
 fun installFeature(service: Any): ApplicationScope = {
+  registeredRoutes.clear()
+
   install(ContentNegotiation) {
     jackson { }
   }
@@ -36,6 +38,8 @@ fun installFeature(service: Any): ApplicationScope = {
 }
 
 fun installRoute(service: Any): ApplicationScope = {
+  registeredRoutes.clear()
+
   install(ContentNegotiation) {
     jackson { }
   }

--- a/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/install.kt
+++ b/ktor-retrofit/src/test/kotlin/com/bnorm/ktor/retrofit/install.kt
@@ -26,8 +26,6 @@ import io.ktor.routing.routing
 typealias ApplicationScope = Application.() -> Unit
 
 fun installFeature(service: Any): ApplicationScope = {
-  registeredRoutes.clear()
-
   install(ContentNegotiation) {
     jackson { }
   }
@@ -38,8 +36,6 @@ fun installFeature(service: Any): ApplicationScope = {
 }
 
 fun installRoute(service: Any): ApplicationScope = {
-  registeredRoutes.clear()
-
   install(ContentNegotiation) {
     jackson { }
   }


### PR DESCRIPTION
A naive check to ensure duplicate routes don't exist in the retrofit interface

Meant to close #5 